### PR TITLE
[FIXED JENKINS-44153] Include CpsScmFlowDefinition.getSCM() in SCMs list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <no-test-jar>false</no-test-jar>
+        <git-plugin.version>3.3.0</git-plugin.version>
+        <scm-api.version>2.1.1</scm-api.version>
     </properties>
     <dependencies>
         <dependency>
@@ -80,7 +82,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>1.15</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -92,6 +93,50 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-support</artifactId>
             <version>1.15</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>${scm-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>${scm-api.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -91,6 +91,7 @@ import jenkins.triggers.SCMTriggerItem;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
 import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty;
@@ -552,13 +553,18 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         if (b == null) {
             b = getLastCompletedBuild();
         }
-        if (b == null) {
+        if (b == null && !(getDefinition() instanceof CpsScmFlowDefinition)) {
             return Collections.emptySet();
         }
+        if ((b == null || b.checkouts(null).isEmpty()) && getDefinition() instanceof CpsScmFlowDefinition) {
+            return Collections.singleton(((CpsScmFlowDefinition)getDefinition()).getScm());
+        }
+
         Map<String,SCM> scms = new LinkedHashMap<>();
         for (WorkflowRun.SCMCheckout co : b.checkouts(null)) {
             scms.put(co.scm.getKey(), co.scm);
         }
+
         return scms.values();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -30,9 +30,13 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.model.Item;
 import hudson.model.Items;
+import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -57,6 +61,8 @@ public class PipelineTriggersJobPropertyTest {
     public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule
     public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleGitRepo = new GitSampleRepoRule();
 
     /**
      * Needed to ensure that we get a fresh {@code startsAndStops} with each test run. Has to be *after* rather than
@@ -144,6 +150,37 @@ public class PipelineTriggersJobPropertyTest {
         assertEquals("[null, false, null, false, null, false]", MockTrigger.startsAndStops.toString());
     }
 
+    @Issue("JENKINS-44153")
+    @Test
+    public void triggerPicksUpScriptFromSCM() throws Exception {
+        sampleGitRepo.init();
+        sampleGitRepo.write("Jenkinsfile", "node { git($/" + sampleGitRepo + "/$) }");
+        sampleGitRepo.git("add", "Jenkinsfile");
+        sampleGitRepo.git("commit", "--message=files");
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        String newConfig = StringUtils.replace(org.apache.commons.io.IOUtils.toString(
+                PipelineTriggersJobPropertyTest.class.getResourceAsStream(
+                        "/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPicksUpScriptFromSCM.json"), "UTF-8"),
+                "__SAMPLE_REPO__", sampleGitRepo.toString());
+
+        submitConfig(newConfig, p);
+        SCMTrigger t = getTriggerFromList(SCMTrigger.class,
+                p.getTriggersJobProperty().getTriggers());
+        assertNotNull(t);
+
+        sampleGitRepo.write("OtherFile", "something else");
+        sampleGitRepo.git("add", "OtherFile");
+        sampleGitRepo.git("commit", "--message=files");
+        sampleGitRepo.notifyCommit(r);
+
+        WorkflowRun b = p.getLastBuild();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(b);
+        assertEquals(1, b.number);
+        r.assertLogContains("Cloning the remote Git repository", b);
+    }
+
     @Test
     public void configRoundTrip() throws Exception {
         WorkflowJob defaultCase = r.jenkins.createProject(WorkflowJob.class, "defaultCase");
@@ -179,17 +216,11 @@ public class PipelineTriggersJobPropertyTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "triggerPresent");
         assertNull(getTriggerFromList(QueryingMockTrigger.class,
                 p.getTriggersJobProperty().getTriggers()));
-        JenkinsRule.WebClient wc = r.createWebClient();
         String newConfig = org.apache.commons.io.IOUtils.toString(
                 PipelineTriggersJobPropertyTest.class.getResourceAsStream(
                         "/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPresentDuringStart.json"), "UTF-8");
-        WebRequest request = new WebRequest(new URL(p.getAbsoluteUrl() + "configSubmit"), HttpMethod.POST);
-        wc.addCrumb(request);
-        List<NameValuePair> params = new ArrayList<>();
-        params.addAll(request.getRequestParameters());
-        params.add(new NameValuePair("json", newConfig));
-        request.setRequestParameters(params);
-        wc.getPage(request);
+
+        submitConfig(newConfig, p);
         QueryingMockTrigger t = getTriggerFromList(QueryingMockTrigger.class,
                 p.getTriggersJobProperty().getTriggers());
         assertNotNull(t);
@@ -205,6 +236,18 @@ public class PipelineTriggersJobPropertyTest {
         }
 
         return null;
+    }
+
+    private void submitConfig(String config, WorkflowJob p) throws Exception {
+        JenkinsRule.WebClient wc = r.createWebClient();
+
+        WebRequest request = new WebRequest(new URL(p.getAbsoluteUrl() + "configSubmit"), HttpMethod.POST);
+        wc.addCrumb(request);
+        List<NameValuePair> params = new ArrayList<>();
+        params.addAll(request.getRequestParameters());
+        params.add(new NameValuePair("json", config));
+        request.setRequestParameters(params);
+        wc.getPage(request);
     }
 }
 

--- a/src/test/resources/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPicksUpScriptFromSCM.json
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPicksUpScriptFromSCM.json
@@ -1,0 +1,62 @@
+{
+  "name": "trigger",
+  "description": "",
+  "properties": {
+    "stapler-class-bag": "true",
+    "jenkins-model-BuildDiscarderProperty": {
+      "specified": true,
+      "": "0",
+      "strategy": {
+        "daysToKeepStr": "",
+        "numToKeepStr": "10",
+        "artifactDaysToKeepStr": "",
+        "artifactNumToKeepStr": "",
+        "stapler-class": "hudson.tasks.LogRotator",
+        "$class": "hudson.tasks.LogRotator"
+      }
+    },
+    "org-jenkinsci-plugins-workflow-job-properties-DisableConcurrentBuildsJobProperty": {
+      "specified": false
+    },
+    "hudson-model-ParametersDefinitionProperty": {
+      "specified": false
+    },
+    "jenkins-branch-RateLimitBranchProperty$JobPropertyImpl": {
+    },
+    "org-jenkinsci-plugins-workflow-job-properties-PipelineTriggersJobProperty": {
+      "triggers": {
+        "stapler-class-bag": "true",
+        "hudson-triggers-SCMTrigger": {
+          "scmpoll_spec": "",
+          "ignorePostCommitHooks": false
+        }
+      }
+    }
+  },
+  "hasCustomQuietPeriod": false,
+  "quiet_period": "5",
+  "displayNameOrNull": "",
+  "": "1",
+  "definition": {
+    "": "0",
+    "scm": {
+      "userRemoteConfigs": {
+        "url": "__SAMPLE_REPO__",
+        "credentialsId": "",
+        "name": "",
+        "refspec": ""
+      },
+      "branches": {
+        "name": "*/master"
+      },
+      "": "auto",
+      "stapler-class": "hudson.plugins.git.GitSCM",
+      "$class": "hudson.plugins.git.GitSCM"
+    },
+    "scriptPath": "Jenkinsfile",
+    "lightweight": true,
+    "stapler-class": "org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition",
+    "$class": "org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition"
+  },
+  "core:apply": ""
+}


### PR DESCRIPTION
[JENKINS-44153](https://issues.jenkins-ci.org/browse/JENKINS-44153)

Only do so if there is no previous build or the previous build had no checkouts.

This is dependent on @jglick's change in https://github.com/jenkinsci/workflow-job-plugin/pull/42