### PR TITLE
Address how and where we end the AsynchronousExecution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -651,12 +651,18 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         StashManager.clearAll(this);
     }
 
+    public static boolean LOG_GET_EXECUTION = false;
+
     /**
      * Gets the associated execution state, and do a more expensive loading operation if not initialized.
      * Performs all the needed initialization for the execution pre-loading too -- sets the executionPromise, adds Listener, calls onLoad on it etc.
      * @return non-null after the flow has started, even after finished (but may be null temporarily when about to start, or if starting failed)
      */
     public @CheckForNull FlowExecution getExecution() {
+        if (LOG_GET_EXECUTION) {
+            LOGGER.log(Level.SEVERE, "Logging when getExecution was invoked", new Exception("Ran getExecution"));
+        }
+
         if (executionLoaded || execution == null) {  // Avoids highly-contended synchronization on run
             return execution;
         } else {  // Try to lazy-load execution

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1131,9 +1131,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             isAtomic = hint.isAtomicWrite();
         }
 
-        boolean completeAsynchronousExecution = false;
         synchronized (this) {
-            completeAsynchronousExecution = Boolean.TRUE.equals(completed);
             PipelineIOUtils.writeByXStream(this, loc, XSTREAM2, isAtomic);
             SaveableListener.fireOnChange(this, file);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -651,18 +651,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         StashManager.clearAll(this);
     }
 
-    public static boolean LOG_GET_EXECUTION = false;
-
     /**
      * Gets the associated execution state, and do a more expensive loading operation if not initialized.
      * Performs all the needed initialization for the execution pre-loading too -- sets the executionPromise, adds Listener, calls onLoad on it etc.
      * @return non-null after the flow has started, even after finished (but may be null temporarily when about to start, or if starting failed)
      */
     public @CheckForNull FlowExecution getExecution() {
-        if (LOG_GET_EXECUTION) {
-            LOGGER.log(Level.SEVERE, "Logging when getExecution was invoked", new Exception("Ran getExecution"));
-        }
-
         if (executionLoaded || execution == null) {  // Avoids highly-contended synchronization on run
             return execution;
         } else {  // Try to lazy-load execution

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -543,10 +543,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         }
                     } else {   // Execution nulled due to a critical failure, explicitly mark completed
                         completed = Boolean.TRUE;
-                        needsToPersist = true;  // Make sure we save toggled state
                     }
-                } else if (execution == null && completed != Boolean.TRUE) {
-                    needsToPersist = true; // Make sure we save toggled state
+                } else if (execution == null) {
                     completed = Boolean.TRUE;
                 }
                 if (needsToPersist && completed) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
@@ -79,9 +79,8 @@ public class CpsPersistenceTest {
 
     /** Verifies all the assumptions about a cleanly finished build. */
     static void assertCompletedCleanly(WorkflowRun run) throws Exception {
-        if (run.isBuilding()) {
-            System.out.println("Run initially building, going to wait a second to see if it finishes, run="+run);
-            Thread.sleep(1000);
+        while (run.isBuilding()) {
+            Thread.sleep(100); // Somewhat variable speeds
         }
         Assert.assertFalse(run.isBuilding());
         Assert.assertNotNull(run.getResult());
@@ -103,7 +102,9 @@ public class CpsPersistenceTest {
             Stack<BlockStartNode> starts = getCpsBlockStartNodes(cpsExec);
             Assert.assertTrue(starts == null || starts.isEmpty());
             Thread.sleep(1000); // TODO seems to be flaky
-            Assert.assertFalse(cpsExec.blocksRestart());
+            while (cpsExec.blocksRestart()) {
+                Thread.sleep(100);
+            }
         } else {
             System.out.println("WARNING: no FlowExecutionForBuild");
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -129,7 +129,6 @@ public class WorkflowRunRestartTest {
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
             assertNotNull(b.asFlowExecutionOwner());
-            assertNull(b.execution.getOwner());
             assertFalse(b.executionLoaded);
             assertTrue(b.completed);
             assertFalse(b.isBuilding());

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -125,10 +125,13 @@ public class WorkflowRunRestartTest {
             assertTrue(run.executionLoaded);
             assertNotNull(run.getExecution().getOwner());
         });
+        WorkflowRun.LOG_GET_EXECUTION = true;
         story.then(r -> {
+            WorkflowRun.LOG_GET_EXECUTION = true;
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
             assertNotNull(b.asFlowExecutionOwner());
+            assertNull(b.execution.getOwner());
             assertFalse(b.executionLoaded);
             assertTrue(b.completed);
             assertFalse(b.isBuilding());

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -125,13 +125,10 @@ public class WorkflowRunRestartTest {
             assertTrue(run.executionLoaded);
             assertNotNull(run.getExecution().getOwner());
         });
-        WorkflowRun.LOG_GET_EXECUTION = true;
         story.then(r -> {
-            WorkflowRun.LOG_GET_EXECUTION = true;
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
             assertNotNull(b.asFlowExecutionOwner());
-            assertNull(b.execution.getOwner());
             assertFalse(b.executionLoaded);
             assertTrue(b.completed);
             assertFalse(b.isBuilding());


### PR DESCRIPTION
Corrects for cases where the AsynchronousExecution could be left dangling inadvertently.